### PR TITLE
Fix initial version workflow

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -9,27 +9,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       
-      - name: Check PR label
-        uses: danielchabr/pr-labels-checker@v3.1
-        id: check-label
-        with:
-          hasNone: skip_changelog
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Update changelog
-        if: ${{ steps.check-label.outputs.passed }} == true 
         uses: release-drafter/release-drafter@v5
         id: release-drafter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get previous release version
-        if: ${{ steps.check-label.outputs.passed }} == true 
         run: |
           echo "PREV_VER=$(cat pyproject.toml | grep -o -E '(version\s=\s)([[:punct:]])([0-9]+\.[0-9]+\.[0-9]+.+)([[:punct:]])' | cut -d ' ' -f 3 | tr -d '"')" >> $GITHUB_ENV
 
       - name: Get previous bump version
-        if: ${{ steps.check-label.outputs.passed }} == true 
         env:
           PREV_VER: ${{ env.PREV_VER }}
         run: |
@@ -40,24 +30,31 @@ jobs:
           fi
 
       - name: Bump version
-        if: ${{ steps.check-label.outputs.passed }} == true 
         env:
           BUMP_VER: ${{ env.OLD_BUMP }}
         run: |
           echo "NEW_BUMP=$(($BUMP_VER + 1))" >> $GITHUB_ENV
 
+      - name: Set new release version
+        env:
+          RD_RELEASE: ${{ steps.release-drafter.outputs.name }}
+        run: | 
+          if [ ! -z "$RD_RELEASE" ]; then
+            echo "NEW_RELEASE=$RD_RELEASE" >> $GITHUB_ENV
+          else
+            echo "NEW_RELEASE=0.1.0" >> $GITHUB_ENV
+          fi 
+
       - name: Update version in files
-        if: ${{ steps.check-label.outputs.passed }} == true 
         uses: jacobtomlinson/gha-find-replace@master
         with:
           include: 'pyproject.toml'
           find: 'version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
-          replace: 'version = "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}"'
+          replace: 'version = "${{ env.NEW_RELEASE }}-pre.${{ env.NEW_BUMP }}"'
 
       - name: Commit updates
-        if: ${{ steps.check-label.outputs.passed }} == true 
         env:
-          SNAKEBIDS_VERSION: ${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}
+          SNAKEBIDS_VERSION: ${{ env.NEW_RELEASE }}-pre.${{ env.NEW_BUMP }}
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,16 +35,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set new release version
+        env:
+          RD_RELEASE: ${{ steps.release-drafter.outputs.name }}
+        run: | 
+          if [ ! -z "$RD_RELEASE" ]; then
+            echo "NEW_RELEASE=$RD_RELEASE" >> $GITHUB_ENV
+          else
+            echo "NEW_RELEASE=0.1.0" >> $GITHUB_ENV
+          fi 
+
       - name: Update version in files
         uses: jacobtomlinson/gha-find-replace@master
         with:
           include: 'pyproject.toml'
           find: 'version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
-          replace: 'version = "${{ steps.release-drafter.outputs.name }}"'
+          replace: 'version = "${{ env.NEW_RELEASE }}"'
 
       - name: Commit updates
         env:
-          LATEST_VERSION: ${{ steps.release-drafter.outputs.name }}
+          LATEST_VERSION: ${{ env.NEW_RELEASE }}
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -59,6 +69,8 @@ jobs:
         uses: release-drafter/release-drafter@v5
         with:
           publish: true
+          name: ${{ env.NEW_RELEASE }}
+          tag: "v${{ env.NEW_RELEASE }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "funcmasker-flex"
-version = "-pre.3"
+version = "0.1.0-pre.3"
 description = ""
 authors = ["Ali Khan <alik@robarts.ca>"]
 license = "MIT"


### PR DESCRIPTION
This PR just brings in the changes to deal with `release-drafter` not being able to find a previous tag for `v0.1.0`

Also fixes the version, to `0.1.0-pre.3`, which was the last version indicated in the repo (`-pre.3`)