### PR TITLE
readthedocs deps updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ author = 'Ali Khan'
 extensions = [
     "sphinx_rtd_theme",
     "sphinxarg.ext",
-    'm2r',
+    'm2r2',
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,12 @@ author = 'Ali Khan'
 extensions = [
     "sphinx_rtd_theme",
     "sphinxarg.ext",
+    'm2r',
 ]
+
+
+source_suffix = ['.rst', '.md']
+
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,8 @@
    sphinx-quickstart on Thu Jul 30 10:15:34 2020.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
-
-.. include:: ../README.rst
+   
+.. mdinclude:: ../README.md
 
 .. toctree::
    :maxdepth: 1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx-argparse
 sphinx_rtd_theme
-snakebids==0.3.16
+snakebids

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx-argparse
 sphinx_rtd_theme
 git+git://github.com/pvandyken/snakebids@refactor-app#egg=snakebids
-
+m2r

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 sphinx-argparse
 sphinx_rtd_theme
 git+git://github.com/pvandyken/snakebids@refactor-app#egg=snakebids
-m2r
-mistune
-docutils
+mistune<2.0.0 
+m2r==0.2.1 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,5 @@ sphinx-argparse
 sphinx_rtd_theme
 git+git://github.com/pvandyken/snakebids@refactor-app#egg=snakebids
 m2r
+mistune
+docutils

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx-argparse
 sphinx_rtd_theme
-snakebids
+git+git://github.com/pvandyken/snakebids@refactor-app#egg=snakebids
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 sphinx-argparse
 sphinx_rtd_theme
 git+git://github.com/pvandyken/snakebids@refactor-app#egg=snakebids
-mistune<2.0.0 
-m2r==0.2.1 
+m2r2

--- a/funcmasker_flex/run.py
+++ b/funcmasker_flex/run.py
@@ -6,7 +6,7 @@ from snakebids.app import SnakeBidsApp
 
 def get_parser():
     """Exposes parser for sphinx doc generation, cwd is the docs dir"""
-    app = SnakeBidsApp("../", skip_parse_args=True)
+    app = SnakeBidsApp("../")
     return app.parser
 
 


### PR DESCRIPTION
- unpins snakebids 0.3.16
- removes skip_parse_args
- uses m2r2 for markdown readme